### PR TITLE
Implemented error parsing

### DIFF
--- a/src/models/event/event.ts
+++ b/src/models/event/event.ts
@@ -29,7 +29,7 @@ const validateEventOrders = async (orderIds: Types.ObjectId[]) => {
             throw new InHouseError(EventErrors.ORDER_INVALID);
         }
 
-        if (orderIds.filter((_) => _ !== orderId).length >= 1) {
+        if (orderIds.filter((_) => _ === orderId).length > 1) {
             throw new InHouseError(EventErrors.ORDER_DUPLICATED);
         }
     }
@@ -40,6 +40,7 @@ const EventSchema = new Schema({
         type: String,
         required: [true, EventErrors.NAME_REQUIRED],
     },
+    //TODO: Convert to Epoch
     date: {
         type: Date,
         required: [true, EventErrors.DATE_REQUIRED],

--- a/src/models/event/order.ts
+++ b/src/models/event/order.ts
@@ -1,5 +1,5 @@
 import { Schema, Types, model } from "mongoose";
-import { EventOrder, Ingredient } from "karikarihelper";
+import { Ingredient } from "karikarihelper";
 
 // Types
 import { InHouseError, Statics } from "@types";

--- a/src/models/realm.ts
+++ b/src/models/realm.ts
@@ -49,4 +49,18 @@ const RealmSchema = new Schema({
 
 const RealmModel = model(Statics.REALM_COLLECTION_NAME, RealmSchema);
 
+RealmModel.findOne({
+    name: Statics.REALM_ADMIN_NAME,
+}).then((foundRealm) => {
+    if (foundRealm) {
+        return;
+    }
+
+    const adminRealm = new RealmModel();
+
+    adminRealm.name = Statics.REALM_ADMIN_NAME;
+
+    adminRealm.save();
+});
+
 export default RealmModel;

--- a/src/routes/api/v1/admin/index.ts
+++ b/src/routes/api/v1/admin/index.ts
@@ -5,11 +5,9 @@ import { JWTService } from "@services";
 
 // Routes
 import registryRouter from "./registry";
-import operatorRouter from "./operator";
 
 const router = Router();
 
 router.use("/registry", JWTService.refreshCookies, registryRouter);
-router.use("/operator", operatorRouter);
 
 export default router;

--- a/src/routes/api/v1/admin/registry/event/event.ts
+++ b/src/routes/api/v1/admin/registry/event/event.ts
@@ -1,12 +1,12 @@
 import { Router } from "express";
-
-// Services
-import { EventService, RequestService, ResponseService } from "@services";
+import { Operator } from "karikarihelper";
 
 // Types
 import { EventErrors } from "@models";
 import { InHouseError } from "@types";
-import { Operator } from "karikarihelper";
+
+// Services
+import { EventService, RequestService, ResponseService } from "@services";
 
 const router = Router();
 

--- a/src/routes/api/v1/admin/registry/event/order.ts
+++ b/src/routes/api/v1/admin/registry/event/order.ts
@@ -2,15 +2,15 @@ import { Router } from "express";
 import QRCode from "qrcode";
 import { Operator, OrderItemParam, QrCodeRseponse } from "karikarihelper";
 
-// Services
-import { OrderService, RequestService, ResponseService } from "@services";
-
 // Types
 import { OrderErrors } from "@models";
 import { InHouseError } from "@types";
 
 // Enums
 import { OrderStatus } from "@enums";
+
+// Services
+import { OrderService, RequestService, ResponseService } from "@services";
 
 const router = Router();
 

--- a/src/routes/api/v1/admin/registry/menu.ts
+++ b/src/routes/api/v1/admin/registry/menu.ts
@@ -51,7 +51,7 @@ router.get("/self", async (req, res) => {
     }
 });
 
-router.post("/", (req, res) => {
+router.post("/", async (req, res) => {
     try {
         const title = RequestService.queryParamToString(req.body.title);
         const icon = RequestService.queryParamToString(req.body.icon);
@@ -62,12 +62,15 @@ router.post("/", (req, res) => {
             throw new InHouseError(MenuErrors.INVALID, 400);
         }
 
-        const response = MenuService.save(res.locals.operator as Operator, {
-            title: title,
-            icon: icon,
-            route: route,
-            parentId: parentId,
-        });
+        const response = await MenuService.save(
+            res.locals.operator as Operator,
+            {
+                title: title,
+                icon: icon,
+                route: route,
+                parentId: parentId,
+            }
+        );
 
         res.status(200).json(
             ResponseService.generateSucessfulResponse(response)

--- a/src/routes/api/v1/admin/registry/realm.ts
+++ b/src/routes/api/v1/admin/registry/realm.ts
@@ -1,12 +1,12 @@
 import { Router } from "express";
+import { Operator } from "karikarihelper";
+
+// Types
+import { RealmErrors } from "@models";
+import { InHouseError } from "@types";
 
 // Services
 import { RequestService, ResponseService, RealmService } from "@services";
-
-// Models
-import { RealmErrors } from "@models";
-import { Operator } from "karikarihelper";
-import { InHouseError } from "@types";
 
 const router = Router();
 

--- a/src/routes/api/v1/index.ts
+++ b/src/routes/api/v1/index.ts
@@ -1,9 +1,11 @@
 import { Router } from "express";
 
 import adminRouter from "./admin";
+import operatorRouter from "./operator";
 
 const router = Router();
 
 router.use("/admin", adminRouter);
+router.use("/operator", operatorRouter);
 
 export default router;

--- a/src/routes/api/v1/operator.ts
+++ b/src/routes/api/v1/operator.ts
@@ -1,5 +1,9 @@
 import { Router } from "express";
 
+// Types
+import { OperatorErrors } from "@models";
+import { InHouseError } from "@types";
+
 // Services
 import {
     ResponseService,
@@ -7,10 +11,6 @@ import {
     RequestService,
     OperatorService,
 } from "@services";
-
-// Types
-import { OperatorErrors } from "@models";
-import { InHouseError } from "@types";
 
 const router = Router();
 

--- a/src/services/date.ts
+++ b/src/services/date.ts
@@ -1,5 +1,6 @@
 import { DateTime } from "luxon";
 
+//TODO: Convert to Epoch
 export class DateService {
     public static standarizeCurrentDate(targetDate = new Date()): Date {
         const standarizedDate = new Date(targetDate.getTime());

--- a/src/services/models/order.ts
+++ b/src/services/models/order.ts
@@ -118,20 +118,19 @@ export class OrderService {
         newEntry.event = StringService.toObjectId(values.eventId);
         newEntry.status = newEntry.status;
 
-        const foundOperator = await OperatorService.queryById(operator._id);
+        const foundOperator =
+            operator.role === OperatorRole.ADMIN && values.operatorId
+                ? (
+                      await OperatorService.queryById(values.operatorId)
+                  ).toObject<Operator>()
+                : operator;
 
         if (!foundOperator) {
             throw new InHouseError(OperatorErrors.NOT_FOUND, 404);
         }
 
-        if (operator.role === OperatorRole.ADMIN && values.operatorId) {
-            newEntry.operator = foundOperator._id;
-            newEntry.realm = foundOperator.realm._id;
-        } else {
-            newEntry.operator = StringService.toObjectId(operator._id);
-            newEntry.realm = StringService.toObjectId(operator.realm._id);
-        }
-
+        newEntry.operator = StringService.toObjectId(foundOperator._id);
+        newEntry.realm = StringService.toObjectId(foundOperator.realm._id);
         newEntry.client = values.clientName?.trim();
 
         for (const item of values.items) {

--- a/src/services/models/realm.ts
+++ b/src/services/models/realm.ts
@@ -1,17 +1,20 @@
 import {
     Operator,
     OperatorRole,
+    Realm,
     RealmCreatableParams,
     RealmEditableParams,
     RealmQueryableParams,
 } from "karikarihelper";
 
 // Types
-import { InHouseError } from "@types";
+import { InHouseError, Statics } from "@types";
 import { OperatorErrors, RealmModel } from "@models";
 
 // Services
 import { DatabaseService, StringService } from "@services";
+
+let adminRealm: Realm | null = null;
 
 export class RealmService {
     public static visibleParameters = ["name"];
@@ -46,9 +49,23 @@ export class RealmService {
     }
 
     public static async queryId(id: string) {
+        await DatabaseService.getConnection();
+
         return RealmModel.findById(StringService.toObjectId(id)).select(
             RealmService.visibleParameters
         );
+    }
+
+    public static async getAdminRealm() {
+        if (!adminRealm) {
+            const foundRealm = await RealmModel.findOne({
+                name: Statics.REALM_ADMIN_NAME,
+            });
+
+            adminRealm = foundRealm.toObject<Realm>();
+        }
+
+        return adminRealm;
     }
 
     public static async save(operator: Operator, values: RealmCreatableParams) {

--- a/src/services/response.ts
+++ b/src/services/response.ts
@@ -12,9 +12,57 @@ export class ResponseService {
     public static generateFailedResponse(
         description: string
     ): ResponseWrapper<void> {
+        const wasAppendedByMongoose =
+            description.includes("validation failed:");
+
+        if (wasAppendedByMongoose === false) {
+            return {
+                wasSuccessful: false,
+                description: [description],
+            };
+        }
+
         return {
             wasSuccessful: false,
-            description: description,
+            description: ResponseService._parseDescription(description),
         };
+    }
+
+    private static _parseDescription(description: string): string[] {
+        const inHouseErrorDescriptionPrefix = "ERROR";
+
+        const parsedDescription: string[] = [];
+
+        const splittedDescription = description.split(":");
+
+        for (const descriptionBlock of splittedDescription) {
+            const trimmedDescriptionBlock = descriptionBlock.trim();
+            const splittedDescriptionBlock = trimmedDescriptionBlock.split(",");
+
+            if (
+                splittedDescriptionBlock.length === 1 &&
+                trimmedDescriptionBlock.startsWith(
+                    inHouseErrorDescriptionPrefix
+                ) === false
+            ) {
+                continue;
+            }
+
+            for (const deepDescriptionBlock of splittedDescriptionBlock) {
+                const trimmedDeepDescriptionBlock = deepDescriptionBlock.trim();
+
+                if (
+                    trimmedDeepDescriptionBlock.startsWith(
+                        inHouseErrorDescriptionPrefix
+                    ) === false
+                ) {
+                    continue;
+                }
+
+                parsedDescription.push(trimmedDeepDescriptionBlock);
+            }
+        }
+
+        return parsedDescription;
     }
 }

--- a/src/types/response-wrapper.ts
+++ b/src/types/response-wrapper.ts
@@ -1,7 +1,7 @@
 export interface InHouseResponse {
     code: number;
     wasSuccessful: boolean;
-    description?: string;
+    description?: string[];
 }
 
 export interface ResponseWrapper<T> extends Omit<InHouseResponse, "code"> {

--- a/src/types/statics.ts
+++ b/src/types/statics.ts
@@ -13,6 +13,7 @@ export class Statics {
 
     public static REALM_CLIENT_NAME_MIN_LENGTH = 1;
     public static REALM_CLIENT_NAME_MAX_LENGTH = 25;
+    public static REALM_ADMIN_NAME = "Admin";
 
     public static EVENT_COLLECTION_NAME = "events";
     public static MENU_COLLECTION_NAME = "menus";


### PR DESCRIPTION
## Info

As pointed out at #1, `Mongoose` appends messages to thrown errors inside its validators rendering errors messages really hard to use as it is, this PR is focused on fixing that.

_P.S. Also I changed the `operator` auth endpoint location._

## Problems  

1. Current error messages are unusable.

## Fix

- [x] 1.Implemented error parsing at 67087ce491ae69448d2312cba60b05b8fbbcecf5.
